### PR TITLE
Movement blocker validation

### DIFF
--- a/src/figack/client/repl/level.clj
+++ b/src/figack/client/repl/level.clj
@@ -1,5 +1,6 @@
 (ns figack.client.repl.level
-  (:require [figack.client.repl.level
+  (:require [figack.level :as level]
+            [figack.client.repl.level
              [render :as render :refer [Render]]])
   (:import [figack.level Field]))
 
@@ -11,19 +12,13 @@
 (defmethod render-object false [_]
   \?)
 
-(defn objects [field]
-  (->> field :objects vals))
-
-(defn is-empty? [field]
-  (->> field objects empty?))
-
-(defmulti render-field #'is-empty?)
+(defmulti render-field #'level/empty-field?)
 
 (defmethod render-field true [_]
   \.)
 
 (defmethod render-field false [field]
-  (render-object (->> field objects first)))
+  (render-object (->> field level/field-objects first)))
 
 (extend-type Field
   Render

--- a/src/figack/hack.clj
+++ b/src/figack/hack.clj
@@ -86,10 +86,10 @@
           dst (level/get-field-at world new-pos)
           obj-id (:id pos)]
       (dosync
-       (let [obj (get-in @src [:objects obj-id])]
+       (let [obj (get (:objects @src) obj-id)]
          (assert obj (str "The object must be found at the given position:" pos))
          (alter src update :objects dissoc obj-id)
-         (alter dst assoc-in [:objects obj-id] obj)))
+         (alter dst update :objects assoc  obj-id obj)))
       new-pos)
     (catch Exception ex
       (report-exception! ex)

--- a/src/figack/level.clj
+++ b/src/figack/level.clj
@@ -1,22 +1,24 @@
-(ns figack.level)
+(ns figack.level
+  (:require [figack.validations :as validations]))
 
 (def width 40)
 (def height 10)
 
 (defrecord Field [objects])
 
-(defn validate-field [field]
-  (when (-> field :objects count (> 1))
-    (throw (Exception. "Too many objects on one field.")))
-  true)
-
 (defn make-field []
   (map->Field {:objects {}}))
+
+(defn field-objects [field]
+  (->> field :objects vals))
+
+(defn empty-field? [field]
+  (->> field field-objects empty?))
 
 (def empty-field (make-field))
 
 (defn make-field-ref []
-  (ref empty-field :validator validate-field))
+  (ref empty-field :validator #'validations/validate-field))
 
 (defn make-empty-level []
   (into [] (repeatedly (* width height) make-field-ref)))

--- a/src/figack/level.clj
+++ b/src/figack/level.clj
@@ -38,8 +38,5 @@
   "Adds a newly created object `obj` to the field and returns the object id."
   [field obj]
   (let [obj-id (next-object-id)]
-    (alter field
-           assoc-in
-           [:objects obj-id]
-           obj)
+    (alter field update :objects assoc obj-id obj)
     obj-id))

--- a/src/figack/level/beings.clj
+++ b/src/figack/level/beings.clj
@@ -1,3 +1,6 @@
-(ns figack.level.beings)
+(ns figack.level.beings
+  (:require [figack.movement :as movement]))
 
 (defrecord Being [class])
+
+(derive Being movement/blocker)

--- a/src/figack/level/walls.clj
+++ b/src/figack/level/walls.clj
@@ -1,8 +1,11 @@
-(ns figack.level.walls)
+(ns figack.level.walls
+  (:require [figack.movement :as movement]))
 
 (def allowed-dirs #{:WE :NS})
 
 (defrecord Wall [dir])
+
+(derive Wall movement/blocker)
 
 (defn make-wall [dir]
   {:pre [(contains? allowed-dirs dir)]}

--- a/src/figack/movement.clj
+++ b/src/figack/movement.clj
@@ -1,0 +1,61 @@
+(ns figack.movement
+  (:require [figack
+             [level :as level]
+             [validations :as validations]]))
+
+(def allowed-directions #{:N :NE :E :SE :S :SW :W :NW})
+
+(def blocker ::blocker)
+
+(defn blocker? [x]
+  (-> x class (isa? blocker)))
+
+(defn validate-blockers [field]
+  (when (->> field level/field-objects (filter blocker?) count (< 1))
+    (throw (Exception. "Movement is blocked by another object!"))))
+
+(validations/set-field-validator! ::blocked? #'validate-blockers)
+
+(defn new-pos-for-move
+  "Calculates the new virtual position for a given move direction.  Performs no
+  boundary checks."
+  [pos dir]
+  {:pre [(contains? allowed-directions dir)]}
+  (case dir
+    :N  (-> pos                 (update :y dec))
+    :NE (-> pos (update :x inc) (update :y dec))
+    :E  (-> pos (update :x inc))
+    :SE (-> pos (update :x inc) (update :y inc))
+    :S  (-> pos                 (update :y inc))
+    :SW (-> pos (update :x dec) (update :y inc))
+    :W  (-> pos (update :x dec))
+    :NW (-> pos (update :x dec) (update :y dec))))
+
+(defn- report-exception! [^Exception ex]
+  (-> (if (instance? java.lang.IllegalStateException ex)
+        (.getCause ex)
+        ex)
+      .getMessage
+      (or (str ex))
+      println))
+
+(defn move-object-at!
+  "Tries to move an object that should be found in the level `lev` at position
+  `pos` in the direction given by `dir` and returns the new position (which
+  might be unchanged, in case of hitting an obstacle, or different from the
+  expected position, in case of other interactions)."
+  [lev pos dir]
+  (try
+    (let [new-pos (new-pos-for-move pos dir)
+          src (level/get-field-at lev pos)
+          dst (level/get-field-at lev new-pos)
+          obj-id (:id pos)]
+      (dosync
+       (let [obj (get (:objects @src) obj-id)]
+         (assert obj (str "The object must be found at the given position:" pos))
+         (alter src update :objects dissoc obj-id)
+         (alter dst update :objects assoc  obj-id obj)))
+      new-pos)
+    (catch Exception ex
+      (report-exception! ex)
+      pos)))

--- a/src/figack/validations.clj
+++ b/src/figack/validations.clj
@@ -1,0 +1,13 @@
+(ns figack.validations)
+
+(def ^:private field-validators {})
+
+(defn set-field-validator! [key vfn]
+  (alter-var-root #'field-validators assoc key vfn))
+
+(defn validate-field [field]
+  (->> field-validators
+       vals
+       (map #(% field))
+       dorun)
+  true)


### PR DESCRIPTION
New validations may be added from any part of the code.  Validations are run
in no particular order, all must pass without throwing exceptions.

Movement defines a validation for blocking moves by checking if more than one
object is present on a field that are "movement blockers".  Wall and Being are
are denoted as movement blockers because they derive from `movement/blocker`.
This can be defined anywhere in code.

The next interesting question is how to model objects that are sometimes
blockers and sometimes not (like closed vs. open doors), or beings that are no
movement blockers, like ghosts.